### PR TITLE
Bug/5312

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
display placeholder image, if the image is created without image address

If the user doesn't type any image address when creating the item, then there are broken images showing up in both home page, and item detail page.

The src attribute in img tag falls into placeholder.png, if item.image is equal to empty string.

<img width="991" alt="Screen Shot 2022-10-23 at 22 42 57" src="https://user-images.githubusercontent.com/4055221/197399221-6d00e321-ad52-4a12-a5a2-26b62b3d9c38.png">

<img width="359" alt="Screen Shot 2022-10-23 at 22 46 18" src="https://user-images.githubusercontent.com/4055221/197399240-cda88a5c-acea-43d4-8998-6ede4b7b9248.png">

This should prevent empty image urls. In the future, the user might cause this bug again by using wrong image address.

Closes-Bug: #2 

Change-Id: 23b1ecc0907f3b305c10c85b0e4ae0d2287720a6
